### PR TITLE
feat(ui, web): add filter modal to search on <xl screens

### DIFF
--- a/apps/web/src/components/search/filter/filter-modal.tsx
+++ b/apps/web/src/components/search/filter/filter-modal.tsx
@@ -15,7 +15,11 @@ export const FilterModal: FC = () => {
       {show && (
         <Modal>
           <Filter />
-          <Button onClick={() => setShow(false)} variant="rounded-outline">
+
+          <Button
+            onClick={() => setShow(false)}
+            variant="rounded-outline"
+            className="mt-8">
             Apply Filters
           </Button>
         </Modal>

--- a/apps/web/src/components/search/filter/filter-modal.tsx
+++ b/apps/web/src/components/search/filter/filter-modal.tsx
@@ -1,0 +1,25 @@
+import { FC, useState } from "react";
+
+import { Button, Modal } from "@root/ui/components";
+
+import { Filter } from "./filter";
+
+export const FilterModal: FC = () => {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div className="flex justify-center w-full mt-4 -mb-8 2xl:hidden">
+      <Button onClick={() => setShow(true)} variant="outline">
+        Set Filters
+      </Button>
+      {show && (
+        <Modal>
+          <Filter />
+          <Button onClick={() => setShow(false)} variant="rounded-outline">
+            Apply Filters
+          </Button>
+        </Modal>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/search/filter/index.ts
+++ b/apps/web/src/components/search/filter/index.ts
@@ -1,1 +1,2 @@
 export * from "./filter";
+export * from "./filter-modal";

--- a/apps/web/src/pages/search.tsx
+++ b/apps/web/src/pages/search.tsx
@@ -32,7 +32,7 @@ const Search: NextPage<{ searchParams: SearchProps }> = ({ searchParams }) => {
               <div className={styles.postsContainer}>
                 <Posts />
               </div>
-              <div className="hidden xl:block">
+              <div className="hidden 2xl:block">
                 <Filter />
               </div>
             </div>

--- a/apps/web/src/pages/search.tsx
+++ b/apps/web/src/pages/search.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import type { GetServerSideProps, NextPage } from "next";
 import { TabPanel, Tabs } from "react-tabs";
 
+import { Button, Modal } from "@root/ui/components";
 import {
   GetPostsDocument,
   GetPostsQuery,
@@ -10,7 +11,7 @@ import {
 } from "@src/__generated__/graphql";
 import { Layout } from "@src/components/layout";
 import { Posts } from "@src/components/posts";
-import { Filter } from "@src/components/search/filter";
+import { Filter, FilterModal } from "@src/components/search/filter";
 import { NavTabList } from "@src/components/search/nav-tab-list";
 import { SearchProps, SearchProvider } from "@src/context/search";
 import { addApolloState, initializeApollo } from "@src/lib/apollo-client";
@@ -24,12 +25,16 @@ const Search: NextPage<{ searchParams: SearchProps }> = ({ searchParams }) => {
         <Tabs>
           {/* Avoids React Tabs from throwing an error with inequal number of Tab and TabPanel components */}
           {NavTabList({})}
+
           <TabPanel>
+            <FilterModal />
             <div className={styles.container}>
               <div className={styles.postsContainer}>
                 <Posts />
               </div>
-              <Filter />
+              <div className="hidden xl:block">
+                <Filter />
+              </div>
             </div>
           </TabPanel>
         </Tabs>

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -2,6 +2,7 @@ import React from "react";
 export * from "./button";
 export * from "./card";
 export * from "./logo";
+export * from "./modal";
 export * from "./radio";
 export * from "./select";
 export * from "./seperator";

--- a/packages/ui/src/components/modal/index.ts
+++ b/packages/ui/src/components/modal/index.ts
@@ -1,0 +1,1 @@
+export * from "./modal";

--- a/packages/ui/src/components/modal/modal.tsx
+++ b/packages/ui/src/components/modal/modal.tsx
@@ -1,0 +1,36 @@
+import { FC, ReactNode } from "react";
+
+import cx from "classnames";
+
+type Props = {
+  children?: ReactNode;
+  className?: string;
+  maxWidth?: string;
+  maxHeight?: string;
+};
+
+export const Modal: FC<Props> = ({
+  children,
+  className,
+  maxWidth = "max-w-2xl",
+  maxHeight = "max-h-screen",
+}) => (
+  <div className={cx(className, "fixed rounded-xl shadow-md z-50 inset-0")}>
+    <div
+      className={cx(
+        "grid place-items-center h-full max-h-screen overflow-auto text-center md:px-4 md:pb-8"
+      )}>
+      <div
+        className={cx(
+          "inline-block w-full text-left align-middle transition-all transform bg-white md:shadow-xl md:rounded-2xl",
+          maxWidth,
+          maxHeight,
+          className
+        )}>
+        <div className="flex flex-col h-full max-h-screen p-4 overflow-y-auto">
+          {children}
+        </div>
+      </div>
+    </div>
+  </div>
+);


### PR DESCRIPTION
* Adds `modal` component to `ui` package
* `filterModal` which replaces the side modal panel on less than xl screens
![image](https://user-images.githubusercontent.com/41309709/168335921-7a25cb8a-70e0-4ad1-8432-868363bc3333.png)
