### PR TITLE
feat(web): redirect to search page via next config

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,4 +2,13 @@ const withTM = require("next-transpile-modules")(["ui"]);
 
 module.exports = withTM({
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/search",
+        permanent: false,
+      },
+    ];
+  },
 });


### PR DESCRIPTION
# Description

The `next.config.js` file now server-side redirects the `/` page to `/search`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Loading `http://localhost:3000/` and confirming it redirects to `http://localhost:3000/search`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
