### PR TITLE
feat(web): Add "Contact seller for price →" for invalid ppp

### DIFF
--- a/apps/web/src/components/post/post.tsx
+++ b/apps/web/src/components/post/post.tsx
@@ -14,8 +14,8 @@ import { Ribbon } from "./ribbon";
 
 type Props = Unwrap<GetPostsQuery["posts"]>;
 
-const isValidPPP = (ppp) => {
-  return ppp < 2500 && ppp > 200;
+const isValidPPP = (ppp: number | undefined | null) => {
+  return ppp && ppp < 2500 && ppp > 200;
 };
 
 export const Post: FC<Props> = ({

--- a/apps/web/src/components/post/post.tsx
+++ b/apps/web/src/components/post/post.tsx
@@ -14,6 +14,10 @@ import { Ribbon } from "./ribbon";
 
 type Props = Unwrap<GetPostsQuery["posts"]>;
 
+const isValidPPP = (ppp) => {
+  return ppp < 2500 && ppp > 200;
+};
+
 export const Post: FC<Props> = ({
   type,
   title,
@@ -63,7 +67,11 @@ export const Post: FC<Props> = ({
           {description}
         </p>
         <div className="flex items-center justify-between w-full">
-          <p className="text-xl font-bold">{`$${ppp}/month per person`}</p>
+          <p className="text-xl font-bold">
+            {isValidPPP(ppp)
+              ? `$${ppp}/month per person`
+              : `Contact Seller for Price →`}
+          </p>
           <Button
             variant="rounded-outline"
             color="sea"


### PR DESCRIPTION
# Description

When an invalid ppp (not in [200, 2500]) is shown on web, the text instead says Contact Seller for Price
![image](https://user-images.githubusercontent.com/41309709/169156451-550e83d5-8085-4dcb-aaa2-de9b60a05346.png)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Local visual check

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
